### PR TITLE
Release docker image for arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: focal
+
+services:
+  - docker
+
+before_script:
+  - mkdir -p ~/.docker/cli-plugins
+  - wget -O - https://github.com/docker/buildx/releases/download/v0.5.1/buildx-v0.5.1.linux-amd64 > ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+  - docker buildx create --use --name mybuilder
+
+script:
+  - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+  - docker buildx build --platform linux/amd64,linux/arm64 -t cfcommunity/git-multibranch-resource:arm_latest --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.3
+FROM alpine:latest
 
 ENV LANG C
 


### PR DESCRIPTION
Hi

Package Owner: Abhishek Nishant

PR change Details:

Patch Details: Following file has been created and modified :

**.travis.yml:** Added .travis.yml file to build and push the image for both amd64 and arm64 platforms.
**Dockerfile:** Replace base image gliderlabs/alpine:3.3 to alpine:latest


PR Description: Here is my commit message :
Release docker image for arm64.

PR Description:

The following file has been created and modified :
**.travis.yml:** Added .travis.yml file to build and push the image for both amd64 and arm64 platforms.
**Dockerfile:** Replace base image gliderlabs/alpine:3.3 to alpine:latest


Signed-off-by: odidev odidev@puresoftware.com
Reviewer: Pruthvi Teja Reddy
Thanks
Abhishek Nishant